### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :move_to_index, only: [:edit, :update]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -22,9 +23,30 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
+
+
   private
   def item_params
     params.require(:item).permit(:item_name, :discription, :category_id, :condition_id, :price, :shipping_fee_id, :prefecture_id, :ship_day_id, :image).merge(user_id: current_user.id)
+  end
+
+  def move_to_index
+    @item = Item.find(params[:id])
+    unless current_user == @item.user
+      redirect_to action: :index
+    end
   end
 
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,6 +1,3 @@
-<%# cssは商品出品のものを併用しています。
-app/assets/stylesheets/items/new.css %>
-
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -4,13 +4,14 @@ app/assets/stylesheets/items/new.css %>
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>
+
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, url: item_path, local: true do |f| %>
     
     <%= render 'shared/error_messages', model: f.object %>
-    
+  
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -21,7 +22,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -71,16 +72,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-         <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, {}, { class:"select-box", id:"item-shipping-fee-status" } %>
+        <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, {}, { class:"select-box", id:"item-shipping-fee-status" } %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-         <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, { class: 'select-box', id: 'item-prefecture' } %>
+        <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, { class: 'select-box', id: 'item-prefecture' } %>
+        <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-         <%= f.collection_select :ship_day_id, ShipDay.all, :id, :name, {}, { class:"select-box", id:"item-scheduled-delivery" } %>
+        <%= f.collection_select :ship_day_id, ShipDay.all, :id, :name, {}, { class:"select-box", id:"item-scheduled-delivery" } %>
       </div>
     </div>
     <%# /配送について %>
@@ -138,7 +140,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,12 +7,10 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
+    
+    <%= render 'shared/error_messages', model: f.object %>
+    
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :discription, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select :category_id, Category.all, :id, :name, {}, { class:"select-box", id:"item-category" } %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select :condition_id, Condition.all, :id, :name, {}, { class:"select-box", id:"item-sales-status" } %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,16 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+         <%= f.collection_select :shipping_fee_id, ShippingFee.all, :id, :name, {}, { class:"select-box", id:"item-shipping-fee-status" } %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
-        <div class="weight-bold-text">
+         <%= f.collection_select :prefecture_id, Prefecture.all, :id, :name, {}, { class: 'select-box', id: 'item-prefecture' } %>
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+         <%= f.collection_select :ship_day_id, ShipDay.all, :id, :name, {}, { class:"select-box", id:"item-scheduled-delivery" } %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -31,8 +31,6 @@
         <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-       
         <% else %>
         <%# 商品購入ボタン %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,12 +27,10 @@
 
     <% if user_signed_in? %>
       <% if user_signed_in? && current_user.id == @item.user_id %>
-        <%# 商品編集削除ボタン %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
         <% else %>
-        <%# 商品購入ボタン %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show,  :edit, :update]
 end


### PR DESCRIPTION
# What
商品情報編集機能実装

# Why
出品後に商品を編集するためです

- ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/c54ef5b2623b6b7569aab7315efc07de
-  必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/8922f97b9c3728e33339b8d992872524
- 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/16c801f723107ccc1e26d84e45b024e1
- 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/b0be0f1a8e9ce7dd31fb14b05a971149
- ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/ca83c7714763114724c38a617ece0103
- ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/e56ead8b25aa4d62ded4e564bc6ffc37
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/c56fc5ad358c45387784566b950c0fac

ご確認お願いします。